### PR TITLE
Add env var for binaries_version

### DIFF
--- a/__tests__/_/binaries.js
+++ b/__tests__/_/binaries.js
@@ -8,7 +8,7 @@ const zlib = require('zlib');
 
 
 export const p = os.platform();
-export const bv = (binaries_version || version).split('.')[0];
+export const bv = process.env.TON_SDK_BIN_VERSION ? process.env.TON_SDK_BIN_VERSION : (binaries_version || version).split('.')[0];
 const binariesHost = 'sdkbinaries-ws.tonlabs.io';
 export const binariesPath = path.resolve(__dirname, '..');
 
@@ -17,7 +17,7 @@ function downloadAndGunzip(dest, url) {
         const request = http.get(url, response => {
             if (response.statusCode !== 200) {
                 reject({
-                    message: `Download failed with ${response.statusCode}: ${response.statusMessage}`,
+                    message: `Download from ${url} failed with ${response.statusCode}: ${response.statusMessage}`,
                 });
                 return;
             }

--- a/__tests__/_/binaries.js
+++ b/__tests__/_/binaries.js
@@ -1,4 +1,4 @@
-import {version, binaries_version} from '../../package.json';
+import {version} from '../../package.json';
 
 const fs = require('fs');
 const path = require('path');
@@ -8,7 +8,7 @@ const zlib = require('zlib');
 
 
 export const p = os.platform();
-export const bv = process.env.TON_SDK_BIN_VERSION ? process.env.TON_SDK_BIN_VERSION : (binaries_version || version).split('.')[0];
+export const bv = process.env.TON_SDK_BIN_VERSION || (version).split('.')[0];
 const binariesHost = 'sdkbinaries-ws.tonlabs.io';
 export const binariesPath = path.resolve(__dirname, '..');
 

--- a/__tests__/contracts.js
+++ b/__tests__/contracts.js
@@ -24,7 +24,7 @@ import {TONClient, TONClientError} from '../src/TONClient';
 
 import type {TONContractABI, TONContractLoadResult, TONKeyPairData} from '../types';
 import {bv} from './_/binaries';
-import {version, binaries_version} from '../package.json';
+import {version} from '../package.json';
 import {ABIVersions, tests} from './_/init-tests';
 
 const CheckInitParamsPackage = tests.loadPackage('CheckInitParams');
@@ -73,7 +73,7 @@ test('Test versions compatibility', async () => {
     expect(version.split('.')[0])
         .toEqual(ver_builtin.split('.')[0]);
     console.log(`Client version ${version} uses compatible binaries version: ${ver_builtin}`,
-        `\n(requested version: ${binaries_version}; calculated version: ${bv})`);
+        `\n(requested version to download: ${bv})`);
 });
 
 test('load', async () => {

--- a/__tests__/contracts.js
+++ b/__tests__/contracts.js
@@ -24,6 +24,7 @@ import {TONClient, TONClientError} from '../src/TONClient';
 
 import type {TONContractABI, TONContractLoadResult, TONKeyPairData} from '../types';
 import {bv} from './_/binaries';
+import {version, binaries_version} from '../package.json';
 import {ABIVersions, tests} from './_/init-tests';
 
 const CheckInitParamsPackage = tests.loadPackage('CheckInitParams');
@@ -67,11 +68,12 @@ test('removeProps', () => {
         });
 });
 
-test('basic', async () => {
-    const version = await tests.client.config.getVersion();
+test('Test versions compatibility', async () => {
+    const ver_builtin = await tests.client.config.getVersion();
     expect(version.split('.')[0])
-        .toEqual(bv);
-    console.log(`Client uses expected binaries version: ${version}`);
+        .toEqual(ver_builtin.split('.')[0]);
+    console.log(`Client version ${version} uses compatible binaries version: ${ver_builtin}`,
+        `\n(requested version: ${binaries_version}; calculated version: ${bv})`);
 });
 
 test('load', async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "ton-client-js",
 	"version": "0.23.0",
-	"binaries_version": "0.23.1",
 	"description": "TON Client for Java Script",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Prooflink to integration tests with environment variable used (implemented in branch),
TON_SDK_BIN_VERSION set to '0_23_99',
actual binary version is '0.23.102':
https://builder.tonlabs.io/jenkins/job/Integration/job/integration-tests/job/fix-binaries-version/5/execution/node/95/log/
see in log:
```   console.log
     Client version 0.23.0 uses compatible binaries version: 0.23.99 
     (requested version: 0.23.1; calculated version: 0_23_99)
```