### PR TITLE
fix flipper version

### DIFF
--- a/packages/tests-react-native/android/gradle.properties
+++ b/packages/tests-react-native/android/gradle.properties
@@ -25,4 +25,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.54.0
+FLIPPER_VERSION=0.75.1

--- a/packages/tests-react-native/ios/Podfile
+++ b/packages/tests-react-native/ios/Podfile
@@ -17,7 +17,7 @@ target 'tests_runner' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
+  use_flipper!({'Flipper' => '0.75.1'})
   post_install do |installer|
     flipper_post_install(installer)
   end


### PR DESCRIPTION
Fixing Flipper version should make it work with cocoapods 1.10.1